### PR TITLE
fix(message): allow system/developer messages at non-first position

### DIFF
--- a/api/src/main/java/com/ke/assistant/util/MessageUtils.java
+++ b/api/src/main/java/com/ke/assistant/util/MessageUtils.java
@@ -585,7 +585,7 @@ public class MessageUtils {
             return;
         }
         if(cur.getRole().equals("system") || cur.getRole().equals("developer")) {
-            throw new BizParamCheckException("system or developer message must be the first message");
+            return;
         }
         if(cur.getRole().equals("user")) {
             if(!pre.getRole().equals("user")) {


### PR DESCRIPTION
Changed from throwing BizParamCheckException to silently returning when a system or developer message appears after the first position, to avoid breaking requests that include such messages mid-conversation.